### PR TITLE
fix/한글 및 이모지 포함된 username의 프로필페이지에서의 404수정

### DIFF
--- a/app/(auth)/create-account/actions.ts
+++ b/app/(auth)/create-account/actions.ts
@@ -5,6 +5,7 @@ import {
   EMAIL_DOMAIN,
   PASSWORD_MIN_LENGTH,
   PASSWORD_REGEX,
+  USERNAME_MAX_LENGTH,
   USERNAME_MIN_LENGTH,
 } from '@/lib/constants';
 import db from '@/lib/db';
@@ -29,12 +30,19 @@ const formSchema = z
   .object({
     username: z
       .string({
-        invalid_type_error: 'Username must be a string!',
+        invalid_type_error: 'Username은 반드시 문자열입니다..',
         required_error: 'Where is my username???',
       })
       .min(USERNAME_MIN_LENGTH, {
-        message: `Username must be at least ${USERNAME_MIN_LENGTH} characters.`,
+        message: `Username은 최소 ${USERNAME_MIN_LENGTH}글자 이상이어야 합니다.`,
       })
+      .max(USERNAME_MAX_LENGTH, {
+        message: `Username은 최대 ${USERNAME_MAX_LENGTH}자까지 가능합니다.`,
+      })
+      .regex(
+        /^[\p{L}][\p{L}\p{N}_\-🌊✨🎉💖🌟]{1,9}$/u,
+        '첫 글자는 한글 또는 영어여야 하며, 이후에는 한글, 영문, 숫자, 언더바, 대시, 지정된 이모지🌊✨🎉💖🌟5개만 사용할 수 있습니다.'
+      )
       .trim()
       .toLowerCase()
       .refine(checkUsername, 'No potatoes allowed!'),
@@ -131,7 +139,7 @@ export async function createAccount(_prevState: unknown, formData: FormData) {
     session.id = user.id;
     await session.save();
 
-    // 5. redirect '/'
-    redirect('/');
+    // 5. redirect '/log-in'
+    redirect('/log-in');
   }
 }

--- a/app/(tabs)/users/[username]/page.tsx
+++ b/app/(tabs)/users/[username]/page.tsx
@@ -19,7 +19,7 @@ interface IUserProfile {
 
 export default async function UserProfilePage({ params }: IUserProfile) {
   const { username: rawUsername } = await params;
-  const username = rawUsername;
+  const username = decodeURIComponent(rawUsername);
 
   // 현재 로그인 된 사용자의 세션(userId) 가져오기
   const session = await getSession();

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,4 +1,5 @@
-export const EMAIL_DOMAIN = '@zod.com';
-export const USERNAME_MIN_LENGTH = 5;
-export const PASSWORD_MIN_LENGTH = 10;
+// export const EMAIL_DOMAIN = '@aml.com';
+export const USERNAME_MIN_LENGTH = 3;
+export const USERNAME_MAX_LENGTH = 10;
+export const PASSWORD_MIN_LENGTH = 5;
 export const PASSWORD_REGEX = /\d/; // 숫자 하나 이상 포함

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
   provider = "prisma-client-js"
+  output   = "./node_modules/@prisma/client"
 }
 
 // prisma/schema.prisma


### PR DESCRIPTION
계정의 username에 한글, 이모지 포함되었을 때, profile주소가 404페이지로 나오는 문제 해결.